### PR TITLE
bump trivy action version

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -16,7 +16,7 @@ jobs:
           docker build -t wis2box-auth:test .
       - name: Run Trivy vulnerability scanner on wis2box-auth
         if: always()
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.35.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1


### PR DESCRIPTION
As per https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0